### PR TITLE
add on('error')  to the varification request

### DIFF
--- a/lib/recaptcha.js
+++ b/lib/recaptcha.js
@@ -137,6 +137,11 @@ Recaptcha.prototype.verify = function(callback) {
 
     var request = http.request(req_options, function(response) {
         var body = '';
+        
+        response.on('error', function(err) {
+             self.error_code = 'recaptcha-not-reachable';
+             callback(false, 'recaptcha-not-reachable');
+        });
 
         response.on('data', function(chunk) {
             body += chunk;


### PR DESCRIPTION
Yes, it's true, these servers are very rarely down, but I had some trouble with the proxi servers in my office, so I got to experience this cases.

add on('error') with the error-code documented at 
https://developers.google.com/recaptcha/docs/verify#error-recaptcha-not-reachable
